### PR TITLE
Add Plasmodium profile to Autorun config.

### DIFF
--- a/conf/Autorun_deepscreening.config
+++ b/conf/Autorun_deepscreening.config
@@ -78,4 +78,69 @@ profiles {
             }
       }
    }
+
+   Plasmodium_Prescreening {
+      params {
+         config_profile_description = 'HOPs screening MPI-EVA mapping to Human HG19'
+         //Skip pre mapping steps, assumes fastq has been already through adapter removal
+         skip_fastqc = true
+         skip_adapterremoval = true
+         skip_preseq = true
+         skip_deduplication = true
+         skip_damage_calculation = true
+         skip_qualimap = true
+
+         run_bam_filtering = true
+         bam_unmapped_type = 'fastq'
+
+         //HG19 mapping with parameters as in the Autorun pipeline
+         fasta = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.fa'
+         fasta_index = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.fa.fai'
+         bwa_index = '/mnt/archgen/Reference_Genomes/Human/hs37d5/'
+         seq_dict = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.dict'
+         bwaalnn = '0.01'
+         bwaalnl = '16500'
+         bwaalno = '2'
+         
+         //maltextract files
+         maltextract_taxon_list = '/mnt/archgen/users/michel/plasmodium/04-screening/big_screen/pathogen_list.txt'
+
+         //Malt database
+         database = '/mnt/archgen/users/michel/plasmodium/04-screening/custom_db/database'
+
+         //HOPS parameters
+         run_metagenomic_screening = true
+         metagenomic_complexity_filter = false
+         metagenomic_complexity_entropy = 0.3
+         metagenomic_tool = 'malt'
+         metagenomic_min_support_reads = 1
+         percent_identity = 90
+         malt_mode = 'BlastN'
+         malt_alignment_mode = 'SemiGlobal'
+         malt_top_percent = 1
+         malt_min_support_mode = 'reads'
+         malt_min_support_percent = 0.01
+         malt_max_queries = 100
+         malt_memory_mode = 'load'
+         malt_sam_output = false
+         run_maltextract = true
+         maltextract_filter = 'def_anc'
+         maltextract_toppercent = 0.01
+         maltextract_destackingoff = false
+         maltextract_downsamplingoff = false
+         maltextract_duplicateremovaloff = false
+         maltextract_matches = false
+         maltextract_megansummary = true
+         maltextract_percentidentity = 90
+         maltextract_topalignment = false
+      }
+
+      process {
+         withName: malt {
+            clusterOptions = { "-S /bin/bash -V -l h_vmem=390G,virtual_free=390G" }
+            cpus = 36
+            memory = 350.GB            
+            }
+      }
+   }
 }


### PR DESCRIPTION
Differences from Bac/Viral prescreening: 
1. Map to human (with bwa params taken from Autorun for human data)
2. Added Plasmodium taxon list and screening database
3. Changed percent identity for MALT and HOPS to 90 (from 85)